### PR TITLE
chore(release): add release script and remove tag-release plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "tegami": "bun scripts/tegami.mts",
+    "release": "git tag v$(cat VERSION) && git push origin v$(cat VERSION)",
     "sync-versions": "node -e \"const v = require('fs').readFileSync('VERSION','utf8').trim(); ['apps/api/package.json','apps/web/package.json','apps/docs/package.json'].forEach(f => { const p = require('./'+f); p.version = v; require('fs').writeFileSync(f, JSON.stringify(p, null, 2) + '\\n'); }); console.log('Versions synced to', v);\"",
     "postinstall": "bun sync-versions"
   },

--- a/scripts/tegami.mts
+++ b/scripts/tegami.mts
@@ -138,32 +138,12 @@ ${body}
   };
 }
 
-function tagReleasePlugin(): TegamiPlugin {
-  return {
-    name: "tag-release",
-    async afterPublish(this: any) {
-      const pkg = this.graph.get("npm:dequel-api");
-      if (!pkg) return;
-      const pkgJson = JSON.parse(await readFile(join(pkg.path, "package.json"), "utf8"));
-      const tag = `v${pkgJson.version}`;
-      try {
-        execSync(`git tag ${tag}`, { cwd: this.cwd });
-        execSync(`git push origin ${tag}`, { cwd: this.cwd });
-        console.log(`[Tegami] Pushed tag ${tag} — release workflow will trigger`);
-      } catch (e) {
-        console.warn(`[Tegami] Failed to push tag ${tag}:`, e);
-      }
-    },
-  };
-}
-
 const paper = tegami({
   npm: {
     client: "bun",
   },
   plugins: [
     docsChangelogPlugin(),
-    tagReleasePlugin(),
     github({
       repo: REPO,
       release: false,


### PR DESCRIPTION
## Description
Replace the automated Tegami release plugin with a manual npm script that tags and pushes the current version defined in the VERSION file.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [x] CI / Build / Tooling
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Existing tests pass (`bun test` in `apps/api/`)
- [ ] New tests added (if applicable)
- [ ] Manual testing performed (describe steps)

## Checklist

- [ ] My code follows the project's code style (no comments, named exports, functional components, etc.)
- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings or lint errors
- [ ] I have run `bun test` in `apps/api/` and all tests pass
- [ ] I have synced the VERSION file if needed (`bun run sync-versions`)

## Screenshots (if applicable)

| Before | After |
|--------|-------|
| (insert here) | (insert here) |

## Additional Context

Add any other context about the PR here (e.g., migration notes, deployment considerations, rollback strategy).
